### PR TITLE
Feature/cleanup build files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-// use reqwest::blocking::get;
 use chrono::Utc;
 use rusqlite::{params, Connection, Result};
+use std::fs;
 use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use tokio::time::{sleep, Duration};
 
 const BUILD_TOOLS_URL: &str = "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar";


### PR DESCRIPTION
# **Improve Build Cleanup & Code Refactor** 🚀

## **📝 Summary**  
This PR improves the build cleanup process by ensuring unnecessary files and directories are properly deleted after the build completes. Additionally, it removes unused imports and applies a general format cleanup.

## **✅ Changes**  
- 🗑️ **Enhanced build cleanup**:  
  - `BuildTools.jar` is now copied into the build directory before execution.  
  - Cleans up unnecessary files/folders after the build:
    - `work`
    - `Spigot`
    - `CraftBukkit`
    - `Bukkit`
    - `BuildData`
    - `apache-maven-3.9.6`
- 🔄 **Refactored Code**:
  - Removed **unused imports**.
  - Applied **code formatting** for readability.

## **🔍 How to Test**  
1. **Pull this branch**:
   ```sh
   git checkout feature/cleanup-build-files
   ```
2. **Run the project**:
   ```sh
   cargo run
   ```
3. **Verify:**
   - [X] The program runs successfully.
   - [X] The build process works as expected.
   - [X] No errors appear in the logs.

## **🗒️ Related Issues**  
No Related Issues

## **🚀 Additional Notes**  
- This refactor is a **non-breaking change** and should not affect functionality.
- The cleanup logic ensures only the `.jar` file and the BuildTools.log.txt file remains after the build.
